### PR TITLE
WSL上でgitを使えるように設定

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,1 +1,4 @@
 #!/bin/sh
+
+# git操作を行えるようにする
+git config --global --add safe.directory /var/www/html

--- a/.docker/app/.profile
+++ b/.docker/app/.profile
@@ -1,0 +1,21 @@
+# ~/.profile: executed by Bourne-compatible login shells.
+
+if [ "$BASH" ]; then
+  if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+  fi
+fi
+
+mesg n 2> /dev/null || true
+
+if [ -z "$SSH_AUTH_SOCK" ]; then
+   # Check for a currently running instance of the agent
+   RUNNING_AGENT="`ps -ax | grep 'ssh-agent -s' | grep -v grep | wc -l | tr -d '[:space:]'`"
+   if [ "$RUNNING_AGENT" = "0" ]; then
+        # Launch a new instance of the agent
+        ssh-agent -s &> $HOME/.ssh/ssh-agent
+   fi
+   eval `cat $HOME/.ssh/ssh-agent`
+fi
+
+ssh-add $HOME/.ssh/id_ed25519

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
             - database
         volumes:
             - ./.docker/app/php.ini:/usr/local/etc/php/php.ini:ro
+            - ./.docker/app/.profile:/root/.profile:ro
             - ./:/var/www/html/:rw
 
     web:


### PR DESCRIPTION
# 変更内容

- フォルダの所有者が違ってもgit操作が行えるよう`safe.directory`を設定
- DevContainer起動時に`ssh-agent`を自動実行

# 課題

WSL上ではうまく行くが、素のubuntu上だとうまく行かない。GitHub CLIのGit Credential Managerを使ったほうが良いかも。
参考: [Git に GitHub の認証情報をキャッシュする \- GitHub Docs](https://docs.github.com/ja/get-started/getting-started-with-git/caching-your-github-credentials-in-git)