### PR TITLE
PHP Intelephense追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,11 @@
     "shutdownAction": "stopCompose",
     "customizations": {
         "vscode": {
-            "settings": [
-            ],
+            "settings": {
+                "intelephense.environment.phpVersion": "8.3"
+            },
             "extensions": [
+                "bmewburn.vscode-intelephense-client"
             ]
         }
     }


### PR DESCRIPTION
現在はPHP Language Featuresを自動で無効にできない。
しばらくは`@builtin php`で検索してDisable(Workspace)を押すようにする。リビルドしてもこの設定は保存されるようなので一回でOK。