### PR TITLE
Commit時にPHPStanとPHPUnitを走らせるよう変更

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -7,3 +7,7 @@ git config --global --add safe.directory /var/www/html
 composer require phpstan/phpstan --dev
 composer require phpstan/phpstan-strict-rules --dev
 composer require nunomaduro/larastan:^2.0 --dev
+
+# Commit時にpre-commitを走らせるよう設定
+chmod +x .githooks/pre-commit
+git config --local core.hooksPath .githooks

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# PHPファイルが変更された場合はPHPStanとPHPUnitを実行
+CHANGED_PHP_FILES=$(git diff --staged --name-only | grep \\.php)
+if [ -z "$CHANGED_PHP_FILES" ]; then
+    echo "No .php is changed. Skip PHPStan & PHPUnit."
+else
+    echo "Some .php have been changed."
+
+    echo "Run PHPStan."
+    vendor/bin/phpstan analyse --memory-limit 1G
+    if [ $? -ne 0 ]; then
+        echo "PHPStan is not passed. Commit aborted."
+        exit 1;
+    else
+        echo "PHPStan is passed."
+    fi
+
+    echo "Run PHPUnit."
+    php artisan test
+    if [$? -ne 0 ]; then
+        echo "PHPUnit is not passed. Commit aborted."
+        exit 1;
+    else
+        echo "PHPUnit is passed."
+    fi
+fi
+
+exit 0;


### PR DESCRIPTION
# 変更

- `.githooks/pre-commit`
  - 本来`.git/hooks/pre-commit`に書く内容だが、git管理できないので`.githooks/pre-commit`に書いた。
- `.devcontainer/postCreateCommand.sh`
  - `.githooks/pre-commit`に実行権限を付与しないとcommit時にスキップされる。